### PR TITLE
Fix npm run test and npm run client

### DIFF
--- a/TP/src/app/people/add-dialog/add-dialog.component.spec.ts
+++ b/TP/src/app/people/add-dialog/add-dialog.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogRef } from '@angular/material/dialog';
 
 import { AddDialogComponent } from './add-dialog.component';
 
@@ -8,7 +9,8 @@ describe('AddDialogComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [AddDialogComponent]
+      declarations: [AddDialogComponent],
+      providers: [{ provide: MatDialogRef, useValue: {} }]
     }).compileComponents();
   }));
 

--- a/TP/src/app/people/people.component.ts
+++ b/TP/src/app/people/people.component.ts
@@ -2,7 +2,7 @@ import { mergeMap } from 'rxjs/operators';
 
 import { Component, OnInit } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { AddDialogComponent } from './add-dialog/add-dialog.component';
 
 const BASE_URL = 'http://localhost:9000';
@@ -33,7 +33,7 @@ export class PeopleComponent implements OnInit {
   add(person: any) {
     this._http
       .post(`${BASE_URL}/api/peoples/`, person)
-      .pipe(mergeMap(res => this._http.get(`${BASE_URL}/api/peoples/`)))
+      .pipe(mergeMap(_ => this._http.get(`${BASE_URL}/api/peoples/`)))
       .subscribe((people: any[]) => {
         this.people = people;
         this.hideDialog();


### PR DESCRIPTION
This PR addresses 2 issues:
* **Test failure** when `npm run test` due to missing provider for `MatDialogRef` in `AddDialogComponent` test
* **TS compilation failures** when `npm run client` failure due to unused `MAT_DIALOG_DATA` import and unused `res` variable in `PeopleComponent`