### PR TITLE
fix(documentation): typo

### DIFF
--- a/docs/markdown/functionnalities/loop.md
+++ b/docs/markdown/functionnalities/loop.md
@@ -2,7 +2,7 @@
 # L'itération avec la directive *ngFor
 <ul>
     <li>Itère dans une collection et génère un template par élément</li><br>
-    <li><strong>index, odd, event, last</strong> à utiliser en alias dans des variables</li>
+    <li><strong>index, odd, even, last</strong> à utiliser en alias dans des variables</li>
 </ul>
 <br><br>
 ```typescript


### PR DESCRIPTION
La variable mise à disposition par la directive `ngFor` pour savoir si l'index de l'élément est pair est **even** et non pas **event**.